### PR TITLE
Addition of getType() API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.2.1</version>
+		<version>38.0.1</version>
 		<relativePath />
 	</parent>
 
@@ -114,7 +114,6 @@ Board of Regents of the University of Wisconsin-Madison.</license.copyrightOwner
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<jply.version>0.2.0</jply.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,8 @@ Board of Regents of the University of Wisconsin-Madison.</license.copyrightOwner
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
+		<imglib2.version>7.1.0</imglib2.version>
+		<imglib2-roi.version>0.15.0</imglib2-roi.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Bump to latest pom-scijava and bump imglib2 versions.

A binary incompatibility was introduced in ImgLib2 which requires re-compilation of imagej-mesh:

`Views.flatIterable(...)` returns `RandomAccessibleInterval` instead of `IterableInterval`. The reasoning is that `RandomAccessibleInterval` extends `IterableInterval` (since imglib2-7.0.0), and there is no reason to strip the RandomAccess part from the flatIterable result.
